### PR TITLE
 Fix segfaults, decrease audio jitter, decrease CPU load, use structs, add proper ds cropping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Byte-compiled / optimized / DLL files
 *.o
 xx3dsfml
-xx3dsfml.conf
-presets/
 *.conf
 *.a
+presets/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # Byte-compiled / optimized / DLL files
 *.o
 xx3dsfml
+xx3dsfml.conf
+presets/
+*.conf
+*.a

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ xx3dsfml
 *.a
 presets/
 ftd3xx/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ xx3dsfml
 *.conf
 *.a
 presets/
+ftd3xx/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Byte-compiled / optimized / DLL files
+*.o
+xx3dsfml

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,17 @@ SRC_FOLDER := ${FTD3XX_FOLDER}/downloads
 CXX := g++
 FRAMEWORKS_OPTIONS :=
 CLEANUP_CMD := echo "DONE"
+RPATH_ARGS :=
 URL_TIME := 2023/03
 ifeq (${SYS}, Darwin)
 	EXT := dylib
 	CXX := clang++
 	FRAMEWORKS_OPTIONS := -framework Cocoa -framework OpenGL -framework IOKit
+	RPATH_ARGS := -Wl,-rpath /usr/local/lib -Wl,-rpath /opt/homebrew/lib
+	K := $(shell which brew)
+	ifeq ($(.SHELLSTATUS), 0)
+	RPATH_ARGS += -Wl,-rpath $(brew --prefix)/lib
+	endif
 	LIB := libftd3xx-static.a
 	VOL := d3xx-osx.${VER}
 	SRC_FOLDER := /Volumes/${VOL}
@@ -39,7 +45,7 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	${CXX} xx3dsfml.o -o xx3dsfml -std=c++17 ${FRAMEWORKS_OPTIONS} ${FTD3XX_FOLDER}/libftd3xx-static.a -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
+	${CXX} xx3dsfml.o -o xx3dsfml -std=c++17 ${RPATH_ARGS} ${FRAMEWORKS_OPTIONS} ${FTD3XX_FOLDER}/libftd3xx-static.a -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
 
 xx3dsfml.o: xx3dsfml.cpp
 	${CXX} -std=c++17 -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	g++ xx3dsfml.o -o xx3dsfml -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window
+	g++ xx3dsfml.o -o xx3dsfml -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window 
 	rm xx3dsfml.o
 
 xx3dsfml.o: xx3dsfml.cpp

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,21 @@ VER := 1.0.5
 TAR := libftd3xx-linux-arm-v6-hf-${VER}.tgz
 ZIP := echo "ZIP NOT SET"
 FTD3XX_FOLDER := ftd3xx
+SRC_FOLDER := ${FTD3XX_FOLDER}/downloads
 CXX := g++
 FRAMEWORKS_OPTIONS :=
+CLEANUP_CMD := echo "DONE"
 URL_TIME := 2023/03
 ifeq (${SYS}, Darwin)
 	EXT := dylib
 	CXX := clang++
 	FRAMEWORKS_OPTIONS := -framework Cocoa -framework OpenGL -framework IOKit
 	LIB := libftd3xx-static.a
-	TAR := d3xx-osx.${VER}.dmg
-	ZIP := 7z x ${FTD3XX_FOLDER}/downloads/${TAR} -o${FTD3XX_FOLDER}/downloads
+	VOL := d3xx-osx.${VER}
+	SRC_FOLDER := /Volumes/${VOL}
+	TAR := ${VOL}.dmg
+	ZIP := hdiutil attach ${FTD3XX_FOLDER}/downloads/${TAR}
+	CLEANUP_CMD := hdiutil detach ${SRC_FOLDER}
 else ifeq (${SYS}, Linux)
 	EXT := so
 	LIB := libftd3xx-static.a
@@ -53,9 +58,10 @@ download_ftd3xx: remove_ftd3xx
 	mkdir -p ${FTD3XX_FOLDER}/downloads
 	curl https://ftdichip.com/wp-content/uploads/${URL_TIME}/${TAR} -o ${FTD3XX_FOLDER}/downloads/${TAR}
 	${ZIP}
-	cp ${FTD3XX_FOLDER}/downloads/${LIB} ${FTD3XX_FOLDER}
-	cp ${FTD3XX_FOLDER}/downloads/*.h ${FTD3XX_FOLDER}
+	cp ${SRC_FOLDER}/${LIB} ${FTD3XX_FOLDER}
+	cp ${SRC_FOLDER}/*.h ${FTD3XX_FOLDER}
 	rm -fr ${FTD3XX_FOLDER}/downloads
+	${CLEANUP_CMD}
 
 remove_ftd3xx:
 	rm -fr ${FTD3XX_FOLDER}

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	g++ xx3dsfml.o -o xx3dsfml -std=c++17 ${FTD3XX_FOLDER}/libftd3xx-static.a -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
+	g++ xx3dsfml.o -o xx3dsfml -std=c++17 ${FTD3XX_FOLDER}/libftd3xx-static.a -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
 
 xx3dsfml.o: xx3dsfml.cpp
 	g++ -std=c++17 -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	g++ xx3dsfml.o -o xx3dsfml ${FTD3XX_FOLDER}/libftd3xx-static.a -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
+	g++ xx3dsfml.o -o xx3dsfml -std=c++17 ${FTD3XX_FOLDER}/libftd3xx-static.a -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
 
 xx3dsfml.o: xx3dsfml.cpp
-	g++ -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o
+	g++ -std=c++17 -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o
 
 clean:
 	rm -f xx3dsfml *.o

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,13 @@ VER := 1.0.5
 TAR := libftd3xx-linux-arm-v6-hf-${VER}.tgz
 ZIP := echo "ZIP NOT SET"
 FTD3XX_FOLDER := ftd3xx
+CXX := g++
+FRAMEWORKS_OPTIONS :=
 URL_TIME := 2023/03
 ifeq (${SYS}, Darwin)
 	EXT := dylib
+	CXX := clang++
+	FRAMEWORKS_OPTIONS := -framework Cocoa -framework OpenGL -framework IOKit
 	LIB := libftd3xx-static.a
 	TAR := d3xx-osx.${VER}.dmg
 	ZIP := 7z x ${FTD3XX_FOLDER}/downloads/${TAR} -o${FTD3XX_FOLDER}/downloads
@@ -30,10 +34,10 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	g++ xx3dsfml.o -o xx3dsfml -std=c++17 ${FTD3XX_FOLDER}/libftd3xx-static.a -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
+	${CXX} xx3dsfml.o -o xx3dsfml -std=c++17 ${FRAMEWORKS_OPTIONS} ${FTD3XX_FOLDER}/libftd3xx-static.a -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
 
 xx3dsfml.o: xx3dsfml.cpp
-	g++ -std=c++17 -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o
+	${CXX} -std=c++17 -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o
 
 clean:
 	rm -f xx3dsfml *.o

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	g++ xx3dsfml.o -o xx3dsfml ${FTD3XX_FOLDER}/libftd3xx-static.a -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window
+	g++ xx3dsfml.o -o xx3dsfml ${FTD3XX_FOLDER}/libftd3xx-static.a -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window -lpthread
 
 xx3dsfml.o: xx3dsfml.cpp
 	g++ -I ${FTD3XX_FOLDER} -c xx3dsfml.cpp -o xx3dsfml.o

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ SYS := ${shell uname -s}
 ARC := ${shell uname -m}
 VER := 1.0.5
 TAR := libftd3xx-linux-arm-v6-hf-${VER}.tgz
+ZIP := echo "ZIP NOT SET"
+UPD := echo "UPD NOT SET"
 ifeq (${SYS}, Darwin)
 	EXT := dylib
 	LIB := libftd3xx.${VER}.${EXT}
@@ -29,18 +31,23 @@ else ifeq (${SYS}, Linux)
 endif
 
 xx3dsfml: xx3dsfml.o
-	sudo g++ xx3dsfml.o -o xx3dsfml -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window
-	sudo rm xx3dsfml.o
+	g++ xx3dsfml.o -o xx3dsfml -lftd3xx -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window
+	rm xx3dsfml.o
+
+xx3dsfml.o: xx3dsfml.cpp
+	g++ -c xx3dsfml.cpp -o xx3dsfml.o
+
+clean:
+	rm xx3dsfml xx3dsfml.o
+
+install: uninstall install_ftd3xx clean xx3dsfml
 	sudo mkdir -p /usr/local/bin
 	sudo mv xx3dsfml /usr/local/bin
 
-xx3dsfml.o: xx3dsfml.cpp
-	sudo g++ -c xx3dsfml.cpp -o xx3dsfml.o
-
-clean:
+uninstall: uninstall_ftd3xx
 	sudo rm /usr/local/bin/xx3dsfml
 
-install:
+install_ftd3xx:
 	sudo mkdir temp
 	sudo curl https://ftdichip.com/wp-content/uploads/2023/03/${TAR} -o temp/${TAR}
 	sudo ${ZIP}
@@ -54,6 +61,6 @@ install:
 	sudo chmod 644 /usr/local/include/libftd3xx/*.h
 	sudo rm -r temp
 
-uninstall:
+uninstall_ftd3xx:
 	sudo rm /usr/local/lib/libftd3xx.*
 	sudo rm -r /usr/local/include/libftd3xx

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install: uninstall clean xx3dsfml
 	sudo mkdir -p /usr/local/bin
 	sudo mv xx3dsfml /usr/local/bin
 
-uninstall: uninstall_ftd3xx
+uninstall:
 	sudo rm -f /usr/local/bin/xx3dsfml
 
 ifeq (4.3,$(firstword $(sort $(MAKE_VERSION) 4.3)))

--- a/README.md
+++ b/README.md
@@ -14,27 +14,30 @@ xx3dsfml is a multi-platform capture program for [3dscapture's](https://3dscaptu
 - Four configurable user layouts that can be saved to and loaded from on the fly.
 
 _Note: DS games boot in scaled resolution mode by default. Holding START or SELECT while launching DS games will boot in native resolution mode._
+_Note: Make sure the 3DS audio is not set to Surround._
 
 #### Dependencies
 
 xx3dsfml has two dependencies: [FTDI's D3XX driver](https://ftdichip.com/drivers/d3xx-drivers/) and [SFML](https://www.sfml-dev.org/).
 
-The D3XX driver can be installed with the provided Makefile as outlined in the __Install__ section below. As of now, this is the required way to install the driver in order to fully support this program. This is because the latest driver (1.0.14) is bugged, so the previous version (1.0.5) will be installed instead. The latest version can still be used, but it will be unstable and prone to crashing in certain circumstances.
+The D3XX driver can be installed with the provided Makefile as outlined in the [Compile and Install](#compile-and-install) section. As of now, this is the required way to install the driver in order to fully support this program. This is because the latest driver (1.0.14) is bugged, so the previous version (1.0.5) will be installed instead. The latest version can still be used, but it will be unstable and prone to crashing in certain circumstances.
 
 The native C++ version of SFML, including its development files, also needs to be installed. The simplest way to accomplish this would be using a package manager, which [Homebrew](https://brew.sh/) is a popular choice for on macOS.
 
 _Note: C++ is the default language for SFML and is not a binding._
 
-#### Install
+#### Compile and Install
 
 Installing xx3dsfml is as simple as compiling the xx3dsfml.cpp code. A Makefile is provided with the following functionality:
 
-- `make`:            This will create a systemwide executable, which can be executed via the `xx3dsfml` command from any directory.
-- `make clean`:      This will remove the systemwide executable.
-- `make install`:    This will install the D3XX driver, including its development files.
-- `make uninstall`:  This will uninstall the D3XX driver, including its development files.
+1. `make`:                    This will generate the executable. If it's the first time building the application, calling `make download_ftd3xx` first is required.
+2. `make clean`:              This will clean the build artifacts.
+3. `make download_ftd3xx`:    This will download the D3XX driver in the folder. Required to build.
+3. `make remove_ftd3xx`:      This will remove the D3XX driver in the folder, if present.
+3. `make install`:            This will install the executable as a systemwide command, which can be called using `xx3dsfml` in the terminal from any directory.
+4. `make uninstall`:          This will remove the systemwide executable.
 
-When utilizing the Makefile, you may be prompted for a password, and on macOS, you may also be prompted to install the Apple Command Line Developer Tools first. Additionally, on macOS, a command line capable version of 7-Zip is required at this time. This is because the previous version of the D3XX driver (1.0.5) is only available as a DMG file, which 7-Zip is capable of extracting from.
+When utilizing the Makefile, you may be prompted for a password when using the install option, and on macOS, you may also be prompted to install the Apple Command Line Developer Tools first.
 
 #### Controls
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _Note: Make sure the 3DS audio is not set to Surround._
 
 xx3dsfml has two dependencies: [FTDI's D3XX driver](https://ftdichip.com/drivers/d3xx-drivers/) and [SFML](https://www.sfml-dev.org/).
 
-The D3XX driver can be installed with the provided Makefile as outlined in the [Compile and Install](#compile-and-install) section. As of now, this is the required way to install the driver in order to fully support this program. This is because the latest driver (1.0.14) is bugged, so the previous version (1.0.5) will be installed instead. The latest version can still be used, but it will be unstable and prone to crashing in certain circumstances.
+The D3XX driver will be automatically downloaded with the provided Makefile. As of writing, it will not be the latest version of the driver. This is because the latest driver (1.0.14) is bugged, so the previous version (1.0.5) will be installed instead. The latest version can still be used, but it will be unstable and prone to crashing in certain circumstances.
 
 The native C++ version of SFML, including its development files, also needs to be installed. The simplest way to accomplish this would be using a package manager, which [Homebrew](https://brew.sh/) is a popular choice for on macOS.
 
@@ -30,10 +30,8 @@ _Note: C++ is the default language for SFML and is not a binding._
 
 Installing xx3dsfml is as simple as compiling the xx3dsfml.cpp code. A Makefile is provided with the following functionality:
 
-1. `make`:                    This will generate the executable. If it's the first time building the application, calling `make download_ftd3xx` first is required.
+1. `make`:                    This will generate the executable.
 2. `make clean`:              This will clean the build artifacts.
-3. `make download_ftd3xx`:    This will download the D3XX driver in the folder. Required to build.
-3. `make remove_ftd3xx`:      This will remove the D3XX driver in the folder, if present.
 3. `make install`:            This will install the executable as a systemwide command, which can be called using `xx3dsfml` in the terminal from any directory.
 4. `make uninstall`:          This will remove the systemwide executable.
 

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -817,6 +817,7 @@ void render(bool skip_io) {
 	int curr_out, prev_out = BUF_COUNT - 1;
 	bool loaded_split = false;
 	bool re_init = true;
+	bool do_blank_screen = true;
 
 	g_in_tex.create(CAP_WIDTH, CAP_HEIGHT);
 
@@ -880,9 +881,23 @@ void render(bool skip_io) {
 
 				prev_out = curr_out;
 			}
+			do_blank_screen = true;
 		}
 		else {
 			sf::sleep(sf::milliseconds(1000/USB_CHECKS_PER_SECOND));
+		}
+
+		if((!g_connected) && do_blank_screen) {
+			memset(out_buf, 0, FRAME_SIZE_RGBA);
+			g_in_tex.update(out_buf, CAP_WIDTH, CAP_HEIGHT, 0, 0);
+			if (loaded_split) {
+				top_screen.draw();
+				bot_screen.draw();
+			}
+			else {
+				joint_screen.draw(&top_screen.m_in_rect, &bot_screen.m_in_rect);
+			}
+			do_blank_screen = false;
 		}
 
 		int load_index = 0;

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -663,6 +663,7 @@ start:
 		if (!g_running) {
 			return;
 		}
+		sf::sleep(sf::milliseconds(1000/BAD_USB_CHECKS_PER_SECOND));
 	}
 
 	for (g_curr_in = 0; g_curr_in < BUF_COUNT; ++g_curr_in) {
@@ -725,11 +726,13 @@ end:
 	g_close_success = false;
 	g_connected = false;
 	for (g_curr_in = 0; g_curr_in < BUF_COUNT; ++g_curr_in) {
+		#ifndef SAFER_QUIT
 		if(!bad_close) {
 			ftStatus = FT_GetOverlappedResult(g_handle, &overlap[g_curr_in], &g_read[g_curr_in], true);
 			if(FT_FAILED(ftStatus))
 				bad_close = true;
 		}
+		#endif
 		if (FT_ReleaseOverlapped(g_handle, &overlap[g_curr_in])) {
 			printf("[%s] Release failed.\n", NAME);
 		}
@@ -838,7 +841,7 @@ void playback() {
 			num_consecutive_audio_stop = 0;
 		}
 
-		if(num_sleeps < USB_NUM_CHECKS) {
+		if((num_sleeps < USB_NUM_CHECKS) || (!g_connected)) {
 			sf::sleep(sf::milliseconds(1000/num_usb_checks_per_second));
 			++num_sleeps;
 		}
@@ -937,7 +940,7 @@ void render(bool skip_io) {
 			}
 		}
 
-		if(num_sleeps < USB_NUM_CHECKS) {
+		if((num_sleeps < USB_NUM_CHECKS) || (!g_connected)) {
 			sf::sleep(sf::milliseconds(1000/num_usb_checks_per_second));
 			++num_sleeps;
 		}

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -688,8 +688,8 @@ void map(UCHAR *p_in, sf::Int16 *p_out) {
 }
 
 void playback() {
-	sf::Int16 out_buf[BUF_COUNT][SAMPLE_SIZE_16];
-	int curr_out, prev_out = 0;
+	sf::Int16 out_buf[AUDIO_BUF_COUNT][SAMPLE_SIZE_16];
+	int curr_out, prev_out = BUF_COUNT - 1, audio_buf_counter = 0;
 
 	g_audio.setVolume(g_mute ? 0 : g_volume);
 
@@ -697,13 +697,15 @@ void playback() {
 		curr_out = (g_curr_in - 1 + BUF_COUNT) % BUF_COUNT;
 
 		if (curr_out != prev_out) {
-			if (g_read[curr_out] > FRAME_SIZE_RGB && g_samples.size() < SAMPLE_LIMIT) {
-				map(&g_in_buf[curr_out][FRAME_SIZE_RGB], out_buf[curr_out]);
-				g_samples.emplace(out_buf[curr_out], (g_read[curr_out] - FRAME_SIZE_RGB) / 2);
-			}
-
-			if (g_audio.getStatus() != sf::SoundStream::Playing) {
-				g_audio.play();
+			if (g_read[curr_out] > FRAME_SIZE_RGB) {
+				map(&g_in_buf[curr_out][FRAME_SIZE_RGB], out_buf[audio_buf_counter]);
+				g_samples.emplace(out_buf[audio_buf_counter], (g_read[curr_out] - FRAME_SIZE_RGB) / 2);
+				
+				if(++audio_buf_counter >= AUDIO_BUF_COUNT)
+				    audio_buf_counter -= AUDIO_BUF_COUNT;
+			    if (g_audio.getStatus() != sf::SoundStream::Playing) {
+				    g_audio.play();
+			    }
 			}
 
 			prev_out = curr_out;

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -557,7 +557,10 @@ private:
 		this->m_win.create(sf::VideoMode(this->m_width * this->m_info.scaling, this->m_height * this->m_info.scaling), this->title());
 		this->m_win.setView(this->m_view);
 
-		g_vsync ? this->m_win.setVerticalSyncEnabled(true) : this->m_win.setFramerateLimit(FRAMERATE_LIMIT);
+		if(this->m_stype == Screen::ScreenType::JOINT)
+			g_vsync ? this->m_win.setVerticalSyncEnabled(true) : this->m_win.setFramerateLimit(FRAMERATE_LIMIT);
+		else
+			this->m_win.setFramerateLimit(FRAMERATE_LIMIT);
 	}
 
 	void rotate() {

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -391,7 +391,11 @@ public:
 					this->m_out_tex.setSmooth(this->m_info.is_blurred = !this->m_info.is_blurred);
 					break;
 
+				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
 				case sf::Keyboard::Hyphen:
+				#else
+				case sf::Keyboard::Dash:
+				#endif
 					this->m_info.scaling -= 0.5;
 					if (this->m_info.scaling < 1.25)
 						this->m_info.scaling = 1.0;
@@ -419,7 +423,11 @@ public:
 
 					break;
 
+				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
 				case sf::Keyboard::Apostrophe:
+				#else
+				case sf::Keyboard::Quote:
+				#endif
 					this->m_info.crop_kind = static_cast<Crop>((this->m_info.crop_kind + 1) % Crop::END);
 
 					this->crop();
@@ -427,7 +435,12 @@ public:
 
 					break;
 
+
+				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
 				case sf::Keyboard::Semicolon:
+				#else
+				case sf::Keyboard::SemiColon:
+				#endif
 					this->m_info.crop_kind = static_cast<Crop>(((this->m_info.crop_kind - 1) % Crop::END + Crop::END) % Crop::END);
 
 					this->crop();

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -853,8 +853,8 @@ void playback() {
 						audio_buf_counter = 0;
 					}
 				}
-				prev_out = curr_out;
 			}
+			prev_out = curr_out;
 			
 			loaded_samples = g_samples.size();
 			if (audio.getStatus() != sf::SoundStream::Playing) {
@@ -947,9 +947,8 @@ void render(bool skip_io) {
 				else {
 					joint_screen.draw(&top_screen.m_in_rect, &bot_screen.m_in_rect);
 				}
-
-				prev_out = curr_out;
 			}
+			prev_out = curr_out;
 			do_blank_screen = true;
 		}
 		else {

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -166,14 +166,28 @@ void load_info(std::string key, std::string value, std::string base, ScreenInfo 
 	}
 	if(key == (base + "crop")) {
 		info.crop_kind = static_cast<Crop>(std::stoi(value));
+		switch(info.crop_kind) {
+			case Crop::DEFAULT_3DS:
+			case Crop::SCALED_DS:
+			case Crop::NATIVE_DS:
+				break;
+			default:
+			info.crop_kind = Crop::DEFAULT_3DS;
+		}
 		return;
 	}
 	if(key == (base + "rotation")) {
 		info.rotation = std::stoi(value);
+		info.rotation %= 360;
+		info.rotation += (info.rotation < 0) ? 360 : 0;
 		return;
 	}
 	if(key == (base + "scale")) {
 		info.scaling = std::stod(value);
+		if(info.scaling < 1.25)
+			info.scaling = 1.0;
+		if(info.scaling > 44.75)
+			info.scaling = 45.0;
 		return;
 	}
 }
@@ -213,7 +227,12 @@ bool load(std::string path, std::string name, ScreenInfo &top_info, ScreenInfo &
 				}
 
 				if (key == "volume") {
-					g_volume = std::stoi(value);
+					int pre_loaded_volume = std::stoi(value);
+					if(pre_loaded_volume < 0)
+						pre_loaded_volume = 0;
+					if(pre_loaded_volume > 100)
+						pre_loaded_volume = 100;
+					g_volume = pre_loaded_volume;
 					continue;
 				}
 			}

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -180,6 +180,12 @@ public:
 		if(mute && (mute == loaded_mute)) {
 			return;
 		}
+
+		if(volume < 0)
+			volume = 0;
+		if(volume > 100)
+			volume = 100;
+
 		if(mute != loaded_mute) {
 			loaded_mute = mute;
 			loaded_volume = volume;

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -487,43 +487,40 @@ public:
 	}
 
 	void poll() {
-		while (this->m_win.pollEvent(this->m_event)) {
-			switch (this->m_event.type) {
+		sf::Event event;
+		while (this->m_win.pollEvent(event)) {
+			switch (event.type) {
 			case sf::Event::Closed:
 				g_running = false;
 				break;
 
-			case sf::Event::KeyPressed:
-				switch (this->m_event.key.code) {
-				case sf::Keyboard::C:
+			case sf::Event::TextEntered:
+				switch (event.text.unicode) {
+				case 'c':
 					g_connected = connect(true);
 					break;
 
-				case sf::Keyboard::S:
+				case 's':
 					g_split = !g_split;
 					break;
 
-				case sf::Keyboard::B:
+				case 'b':
 					this->m_out_tex.setSmooth(this->m_info.is_blurred = !this->m_info.is_blurred);
 					break;
 
-				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
-				case sf::Keyboard::Hyphen:
-				#else
-				case sf::Keyboard::Dash:
-				#endif
+				case '-':
 					this->m_info.scaling -= 0.5;
 					if (this->m_info.scaling < 1.25)
 						this->m_info.scaling = 1.0;
 					break;
 
-				case sf::Keyboard::Equal:
+				case '=':
 					this->m_info.scaling += 0.5;
 					if (this->m_info.scaling > 44.75)
 						this->m_info.scaling = 45.0;
 					break;
 
-				case sf::Keyboard::LBracket:
+				case '(':
 					std::swap(this->m_width, this->m_height);
 
 					this->m_info.rotation = (this->m_info.rotation + 90) % 360;
@@ -531,7 +528,7 @@ public:
 
 					break;
 
-				case sf::Keyboard::RBracket:
+				case ')':
 					std::swap(this->m_width, this->m_height);
 
 					this->m_info.rotation = (this->m_info.rotation + 270) % 360;
@@ -539,11 +536,7 @@ public:
 
 					break;
 
-				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
-				case sf::Keyboard::Apostrophe:
-				#else
-				case sf::Keyboard::Quote:
-				#endif
+				case '\'':
 					this->m_info.crop_kind = static_cast<Crop>((this->m_info.crop_kind + 1) % Crop::END);
 
 					this->crop();
@@ -551,12 +544,7 @@ public:
 
 					break;
 
-
-				#if (SFML_VERSION_MAJOR > 2) || ((SFML_VERSION_MAJOR == 2) && (SFML_VERSION_MINOR >= 6))
-				case sf::Keyboard::Semicolon:
-				#else
-				case sf::Keyboard::SemiColon:
-				#endif
+				case ';':
 					this->m_info.crop_kind = static_cast<Crop>(((this->m_info.crop_kind - 1) % Crop::END + Crop::END) % Crop::END);
 
 					this->crop();
@@ -564,36 +552,44 @@ public:
 
 					break;
 
-				case sf::Keyboard::M:
+				case 'm':
 					g_mute = !g_mute;
 					break;
 
-				case sf::Keyboard::Comma:
+				case ',':
 					g_mute = false;
 					g_volume -= 5;
 					if(g_volume < 0)
 						g_volume = 0;
 					break;
 
-				case sf::Keyboard::Period:
+				case '.':
 					g_mute = false;
 					g_volume += 5;
 					if(g_volume > 100)
 						g_volume = 100;
 					break;
 
+				default:
+					break;
+				}
+
+				break;
+
+			case sf::Event::KeyPressed:
+				switch (event.key.code) {
 				case sf::Keyboard::F1:
 				case sf::Keyboard::F2:
 				case sf::Keyboard::F3:
 				case sf::Keyboard::F4:
-					this->m_prepare_load = this->m_event.key.code - sf::Keyboard::F1 + 1;
+					this->m_prepare_load = event.key.code - sf::Keyboard::F1 + 1;
 					break;
 
 				case sf::Keyboard::F5:
 				case sf::Keyboard::F6:
 				case sf::Keyboard::F7:
 				case sf::Keyboard::F8:
-					this->m_prepare_save = this->m_event.key.code - sf::Keyboard::F5 + 1;
+					this->m_prepare_save = event.key.code - sf::Keyboard::F5 + 1;
 					break;
 				}
 
@@ -654,7 +650,6 @@ private:
 	sf::RectangleShape m_out_rect;
 
 	sf::View m_view;
-	sf::Event m_event;
 
 	bool horizontal() {
 		return this->m_info.rotation / 10 % 2;

--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -3,7 +3,7 @@
  * Copyright 2023 Chris Malnick. All rights reserved.
  */
 
-#include <libftd3xx/ftd3xx.h>
+#include "ftd3xx.h"
 
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>


### PR DESCRIPTION
Fixes segfaults when closing the application, bad memory accesses, and a race condition when accessing curr_in (which caused issues when removing -O3/Ofast, so now the program will work fine even without that flag).

Reintroduces part of the old audio code (and fixes issues with it, while keeping it in a separate thread), as the new one could enter a loop of going over itself multiple times, causing it to never converge and keep doing "crunchy sounds".

Makes it so if the audio output is changed, the audio is restarted properly.

Introduces properly timed sleeps which decrease the total CPU load, and reduces audio and video jitter.

Creates "USB disconnect" safe settings, which are disabled by default, but are available for usage with macros.

Adds proper DS mode cropping (to activate proper DS mode, hold start while launching a DSi title or DS cartridge. This will make it so the game is launched in pixel perfect mode, without any blurring/cropping).

Creates struct for screen info which can be loaded/saved, to make it easier to load/save them.