### PR TITLE
Fix device being non-functional when closing the window normally on macOS

### DIFF
--- a/xx3dsfml.cpp
+++ b/xx3dsfml.cpp
@@ -570,6 +570,9 @@ void capture() {
 	}
 
 end:
+	// BULK_IN seems to get stuck on macOS which prevents the device from working until reinsertion, this fixes it somehow
+	FT_ReadPipe(g_handle, BULK_IN, g_in_buf[g_curr_in], BUF_SIZE, &g_read[g_curr_in], 1);
+
 	for (g_curr_in = 0; g_curr_in < BUF_COUNT; ++g_curr_in) {
 		if (FT_ReleaseOverlapped(g_handle, &overlap[g_curr_in])) {
 			printf("[%s] Release failed.\n", NAME);


### PR DESCRIPTION
On macOS, for some reason when closing the window normally (not via eg killing the process) it seems the USB device gets stuck (the BULK_IN pipe apparently, even FT_AbortPipe stalls indefinitely, FT_ClearStreamPipe and FT_FlushPipe don't do anything) which then requires physical reinsertion. The only way I found to work around it is adding this bogus FT_ReadPipe, it actually fails but somehow fixes this weird state.